### PR TITLE
Advertisement feature

### DIFF
--- a/business_banking/lib/features/advertisement/api/ad_service.dart
+++ b/business_banking/lib/features/advertisement/api/ad_service.dart
@@ -1,0 +1,17 @@
+import 'package:business_banking/features/advertisement/api/ad_service_request_model.dart';
+import 'package:business_banking/features/advertisement/api/ad_service_response_model.dart';
+import 'package:business_banking/locator.dart';
+import 'package:clean_framework/clean_framework.dart';
+import 'package:clean_framework/clean_framework_defaults.dart';
+
+class AdService
+    extends EitherService<AdServiceRequestModel, AdServiceResponseModel> {
+  AdService()
+      : super(
+            method: RestMethod.get, restApi: ExampleLocator().api, path: "ads");
+
+  @override
+  AdServiceResponseModel parseResponse(Map<String, dynamic> jsonResponse) {
+    return AdServiceResponseModel.fromJson(jsonResponse);
+  }
+}

--- a/business_banking/lib/features/advertisement/api/ad_service_request_model.dart
+++ b/business_banking/lib/features/advertisement/api/ad_service_request_model.dart
@@ -1,0 +1,12 @@
+import 'package:clean_framework/clean_framework_defaults.dart';
+
+class AdServiceRequestModel implements JsonRequestModel {
+  final String id;
+
+  AdServiceRequestModel({required this.id});
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {'id': id};
+  }
+}

--- a/business_banking/lib/features/advertisement/api/ad_service_response_model.dart
+++ b/business_banking/lib/features/advertisement/api/ad_service_response_model.dart
@@ -1,0 +1,28 @@
+import 'package:clean_framework/clean_framework_defaults.dart';
+
+class AdServiceResponseModel extends JsonResponseModel {
+  final String id;
+  final String adTitle;
+  final String adDescription;
+  final String adImage;
+  final String adIconImage;
+
+  AdServiceResponseModel(this.id, this.adTitle, this.adDescription,
+      this.adIconImage, this.adImage);
+
+  AdServiceResponseModel.fromJson(Map<String, dynamic> json)
+      : id = json['id'] ?? '',
+        adTitle = json['adTitle'] ?? '',
+        adDescription = json['adDescription'] ?? '',
+        adImage = json['adImage'] ?? '',
+        adIconImage = json['adIconImage'] ?? '';
+
+  @override
+  List<Object?> get props => [
+        this.id,
+        this.adTitle,
+        this.adDescription,
+        this.adImage,
+        this.adIconImage
+      ];
+}

--- a/business_banking/lib/features/advertisement/bloc/ad_bloc.dart
+++ b/business_banking/lib/features/advertisement/bloc/ad_bloc.dart
@@ -1,0 +1,20 @@
+import 'package:business_banking/features/advertisement/api/ad_service.dart';
+import 'package:business_banking/features/advertisement/bloc/ad_hub_card_use_case.dart';
+import 'package:business_banking/features/advertisement/model/ad_hub_card_view_model.dart';
+import 'package:clean_framework/clean_framework.dart';
+
+class AdBloc extends Bloc {
+  final adHubCardViewModelPipe = Pipe<AdHubCardViewModel>();
+  AdHubCardUseCase? _useCase;
+
+  AdBloc({AdService? adService}) {
+    _useCase =
+        AdHubCardUseCase((viewModel) => adHubCardViewModelPipe.send(viewModel));
+    adHubCardViewModelPipe.whenListenedDo(() => _useCase!.create());
+  }
+
+  @override
+  void dispose() {
+    adHubCardViewModelPipe.dispose();
+  }
+}

--- a/business_banking/lib/features/advertisement/bloc/ad_hub_card_service_adapter.dart
+++ b/business_banking/lib/features/advertisement/bloc/ad_hub_card_service_adapter.dart
@@ -1,0 +1,21 @@
+import 'package:business_banking/features/advertisement/api/ad_service.dart';
+import 'package:business_banking/features/advertisement/api/ad_service_request_model.dart';
+import 'package:business_banking/features/advertisement/api/ad_service_response_model.dart';
+import 'package:business_banking/features/advertisement/model/ad_entity.dart';
+import 'package:clean_framework/clean_framework.dart';
+
+class AdHubCardServiceAdapter extends ServiceAdapter<AdEntity,
+    AdServiceRequestModel, AdServiceResponseModel, AdService> {
+  AdHubCardServiceAdapter() : super(AdService());
+
+  @override
+  AdEntity createEntity(
+      AdEntity adEntity, AdServiceResponseModel responseModel) {
+    return adEntity.merge(
+        id: responseModel.id,
+        adTitle: responseModel.adTitle,
+        adDescription: responseModel.adDescription,
+        adImage: responseModel.adImage,
+        adIconImage: responseModel.adIconImage) as AdEntity;
+  }
+}

--- a/business_banking/lib/features/advertisement/bloc/ad_hub_card_use_case.dart
+++ b/business_banking/lib/features/advertisement/bloc/ad_hub_card_use_case.dart
@@ -1,0 +1,42 @@
+import 'package:business_banking/features/advertisement/model/ad_entity.dart';
+import 'package:business_banking/features/advertisement/model/ad_hub_card_view_model.dart';
+import 'package:clean_framework/clean_framework.dart';
+import 'package:business_banking/locator.dart';
+import 'package:clean_framework/clean_framework_defaults.dart';
+import 'ad_hub_card_service_adapter.dart';
+
+class AdHubCardUseCase extends UseCase {
+  ViewModelCallback<AdHubCardViewModel> _viewModelCallback;
+  RepositoryScope? _scope;
+
+  AdHubCardUseCase(ViewModelCallback<AdHubCardViewModel> viewModelCallback)
+      : _viewModelCallback = viewModelCallback;
+
+  Future<void> create() async {
+    if (_scope == null) {
+      _scope = ExampleLocator()
+          .repository
+          .create<AdEntity>(AdEntity(), _notifySubscribers);
+    }
+
+    await ExampleLocator()
+        .repository
+        .runServiceAdapter(_scope!, AdHubCardServiceAdapter());
+    AdEntity entity = ExampleLocator().repository.get<AdEntity>(_scope!);
+    _notifySubscribers(entity);
+  }
+
+  void _notifySubscribers(entity) {
+    _viewModelCallback(buildViewModel(entity));
+  }
+
+  AdHubCardViewModel buildViewModel(AdEntity adEntity) {
+    return AdHubCardViewModel(
+      adTitle: adEntity.adTitle,
+      adIconImage: adEntity.adIconImage,
+      id: adEntity.id,
+      adDescription: adEntity.adDescription,
+      adImage: adEntity.adImage,
+    );
+  }
+}

--- a/business_banking/lib/features/advertisement/model/ad_entity.dart
+++ b/business_banking/lib/features/advertisement/model/ad_entity.dart
@@ -1,0 +1,44 @@
+import 'package:clean_framework/clean_framework.dart';
+
+class AdEntity extends Entity {
+  final String id;
+  final String adTitle;
+  final String adDescription;
+  final String adImage;
+  final String adIconImage;
+
+  AdEntity(
+      {List<EntityFailure> errors = const [],
+      String? id,
+      String? adTitle,
+      String? adDescription,
+      String? adImage,
+      String? adIconImage})
+      : id = id ?? '',
+        adTitle = adTitle ?? '',
+        adDescription = adDescription ?? '',
+        adImage = adImage ?? '',
+        adIconImage = adIconImage ?? '',
+        super(errors: errors);
+
+  @override
+  List<Object> get props =>
+      [errors, id, adTitle, adDescription, adImage, adIconImage];
+
+  @override
+  merge(
+      {errors,
+      String? id,
+      String? adTitle,
+      String? adDescription,
+      String? adImage,
+      String? adIconImage}) {
+    return AdEntity(
+        errors: errors ?? this.errors,
+        id: id ?? this.id,
+        adTitle: adTitle ?? this.adTitle,
+        adDescription: adDescription ?? this.adDescription,
+        adImage: adImage ?? this.adImage,
+        adIconImage: adIconImage ?? this.adIconImage);
+  }
+}

--- a/business_banking/lib/features/advertisement/model/ad_hub_card_view_model.dart
+++ b/business_banking/lib/features/advertisement/model/ad_hub_card_view_model.dart
@@ -1,0 +1,19 @@
+import 'package:clean_framework/clean_framework.dart';
+
+class AdHubCardViewModel extends ViewModel {
+  final String id;
+  final String adTitle;
+  final String adDescription;
+  final String adImage;
+  final String adIconImage;
+
+  AdHubCardViewModel(
+      {required this.adTitle,
+      required this.adIconImage,
+      required this.adImage,
+      required this.adDescription,
+      required this.id});
+
+  @override
+  List<Object> get props => [adTitle, adIconImage];
+}

--- a/business_banking/lib/features/advertisement/ui/ad_details/ad_details_presenter.dart
+++ b/business_banking/lib/features/advertisement/ui/ad_details/ad_details_presenter.dart
@@ -1,0 +1,19 @@
+import 'package:business_banking/features/advertisement/bloc/ad_bloc.dart';
+import 'package:business_banking/features/advertisement/model/ad_hub_card_view_model.dart';
+import 'package:business_banking/features/advertisement/ui/ad_details/ad_details_screen.dart';
+import 'package:clean_framework/clean_framework.dart';
+import 'package:flutter/material.dart';
+
+class AdDetailsPresenter
+    extends Presenter<AdBloc, AdHubCardViewModel, AdDetailsScreen> {
+  @override
+  AdDetailsScreen buildScreen(
+      BuildContext context, AdBloc bloc, AdHubCardViewModel viewModel) {
+    return AdDetailsScreen(viewModel: viewModel);
+  }
+
+  @override
+  Stream<AdHubCardViewModel> getViewModelStream(AdBloc bloc) {
+    return bloc.adHubCardViewModelPipe.receive;
+  }
+}

--- a/business_banking/lib/features/advertisement/ui/ad_details/ad_details_screen.dart
+++ b/business_banking/lib/features/advertisement/ui/ad_details/ad_details_screen.dart
@@ -1,0 +1,55 @@
+import 'package:business_banking/features/advertisement/model/ad_hub_card_view_model.dart';
+import 'package:clean_framework/clean_framework.dart';
+import 'package:flutter/material.dart';
+
+class AdDetailsScreen extends Screen {
+  final AdHubCardViewModel? viewModel;
+
+  AdDetailsScreen({this.viewModel});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Colors.green,
+        title: Text(
+          viewModel!.adTitle,
+        ),
+      ),
+      backgroundColor: Colors.grey[300],
+      body: SingleChildScrollView(
+        child: Card(
+          child: Column(
+            children: [
+              Container(
+                padding: const EdgeInsets.symmetric(
+                    vertical: 18.0, horizontal: 20.0),
+                child: Center(
+                    child: Text(viewModel!.adTitle,
+                        style: TextStyle(fontSize: 24))),
+              ),
+              Container(
+                padding: const EdgeInsets.symmetric(
+                    vertical: 18.0, horizontal: 20.0),
+                child: Center(
+                  child: Image.network(viewModel!.adImage),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(12.0),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceAround,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    Expanded(child: Image.network(viewModel!.adIconImage)),
+                    Expanded(child: Text(viewModel!.adDescription)),
+                  ],
+                ),
+              )
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/business_banking/lib/features/advertisement/ui/ad_details/ad_details_widget.dart
+++ b/business_banking/lib/features/advertisement/ui/ad_details/ad_details_widget.dart
@@ -1,0 +1,13 @@
+import 'package:business_banking/features/advertisement/bloc/ad_bloc.dart';
+import 'package:clean_framework/clean_framework.dart';
+import 'package:flutter/cupertino.dart';
+
+import 'ad_details_presenter.dart';
+
+class AdDetailsWidget extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider<AdBloc>(
+        create: (_) => AdBloc(), child: AdDetailsPresenter());
+  }
+}

--- a/business_banking/lib/features/advertisement/ui/ad_hub_card_presenter.dart
+++ b/business_banking/lib/features/advertisement/ui/ad_hub_card_presenter.dart
@@ -1,0 +1,29 @@
+import 'package:business_banking/features/advertisement/bloc/ad_bloc.dart';
+import 'package:business_banking/features/advertisement/model/ad_hub_card_view_model.dart';
+import 'package:business_banking/features/advertisement/ui/ad_hub_card_screen.dart';
+import 'package:business_banking/routes.dart';
+import 'package:clean_framework/clean_framework.dart';
+import 'package:flutter/material.dart';
+
+class AdHubCardPresenter
+    extends Presenter<AdBloc, AdHubCardViewModel, AdHubCardScreen> {
+  @override
+  AdHubCardScreen buildScreen(
+      BuildContext context, AdBloc bloc, AdHubCardViewModel viewModel) {
+    return AdHubCardScreen(
+        viewModel: viewModel, actions: AdHubCardPresenterActions());
+  }
+
+  @override
+  Stream<AdHubCardViewModel> getViewModelStream(AdBloc bloc) {
+    return bloc.adHubCardViewModelPipe.receive;
+  }
+}
+
+class AdHubCardPresenterActions {
+  AdHubCardPresenterActions();
+
+  void navigateToCreditCardDetails(BuildContext context) {
+    CFRouterScope.of(context).push(BusinessBankingRouter.adDetails);
+  }
+}

--- a/business_banking/lib/features/advertisement/ui/ad_hub_card_screen.dart
+++ b/business_banking/lib/features/advertisement/ui/ad_hub_card_screen.dart
@@ -1,0 +1,74 @@
+import 'package:business_banking/features/advertisement/model/ad_hub_card_view_model.dart';
+import 'package:business_banking/features/advertisement/ui/ad_hub_card_presenter.dart';
+import 'package:clean_framework/clean_framework.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+
+class AdHubCardScreen extends Screen {
+  final AdHubCardViewModel? viewModel;
+  final AdHubCardPresenterActions? actions;
+
+  AdHubCardScreen({this.viewModel, this.actions});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Card(
+        key: Key('adCard'),
+        color: Colors.white,
+        shadowColor: Colors.grey[500],
+        elevation: 3.0,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 10.0, horizontal: 20.0),
+          child: Container(
+            color: Colors.white,
+            child: Column(
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceAround,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    Expanded(
+                        child: Padding(
+                      padding: const EdgeInsets.all(12.0),
+                      child: Text(viewModel!.adTitle,
+                          style: TextStyle(
+                              fontWeight: FontWeight.bold, fontSize: 18)),
+                    )),
+                    Expanded(
+                        child: Padding(
+                      padding: const EdgeInsets.all(20.0),
+                      child: Image.network(viewModel!.adIconImage),
+                    ))
+                  ],
+                ),
+                SizedBox(
+                  height: 50,
+                  width: double.infinity,
+                  child: OutlinedButton(
+                    key: Key('Ad-Card-Learn-More-Button'),
+                    child: Text(
+                      'Learn More',
+                      style: TextStyle(
+                          color: Colors.green,
+                          fontWeight: FontWeight.bold,
+                          fontSize: 20),
+                    ),
+                    style: OutlinedButton.styleFrom(
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(15)),
+                        side: BorderSide(width: 2, color: Colors.green)),
+                    onPressed: () {
+                      actions!.navigateToCreditCardDetails(context);
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/business_banking/lib/features/advertisement/ui/ad_hub_card_widget.dart
+++ b/business_banking/lib/features/advertisement/ui/ad_hub_card_widget.dart
@@ -1,0 +1,14 @@
+import 'package:business_banking/features/advertisement/bloc/ad_bloc.dart';
+import 'package:business_banking/features/advertisement/ui/ad_hub_card_presenter.dart';
+import 'package:clean_framework/clean_framework.dart';
+import 'package:flutter/cupertino.dart';
+
+class AdHubCardWidget extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider<AdBloc>(
+      create: (_) => AdBloc(),
+      child: AdHubCardPresenter(),
+    );
+  }
+}

--- a/business_banking/lib/features/credit_card/ui/payment_response/credit_card_payment_response_actions.dart
+++ b/business_banking/lib/features/credit_card/ui/payment_response/credit_card_payment_response_actions.dart
@@ -3,24 +3,22 @@ import 'package:business_banking/features/credit_card/model/payment_response/cre
 import 'package:clean_framework/clean_framework.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:pdf/widgets.dart' as pw;
-import 'package:printing/printing.dart';
 
 import '../../../../routes.dart';
 
 class CreditCardPaymentResponseActions {
-
   final CreditCardBloc bloc;
   final CreditCardPaymentResponseViewModel viewModel;
 
   CreditCardPaymentResponseActions(this.bloc, this.viewModel);
 
   void navigateBack(BuildContext context) {
-     CFRouterScope.of(context).popUntil(BusinessBankingRouter.creditCardDetailsRoute);
+    CFRouterScope.of(context)
+        .popUntil(BusinessBankingRouter.creditCardDetailsRoute);
   }
 
   void sharePDFPaymentConfirmation(BuildContext context) async {
     pw.Document pdf = await bloc.generatePDFPaymentConfirmation(viewModel);
-    Printing.sharePdf(bytes: await pdf.save(), filename: 'payment-confirmation.pdf');
+    //Printing.sharePdf(bytes: await pdf.save(), filename: 'payment-confirmation.pdf');
   }
-
 }

--- a/business_banking/lib/features/hub/ui/hub_screen.dart
+++ b/business_banking/lib/features/hub/ui/hub_screen.dart
@@ -1,3 +1,4 @@
+import 'package:business_banking/features/advertisement/ui/ad_hub_card_widget.dart';
 import 'package:business_banking/features/budget/ui/first_card/budget_widget.dart';
 import 'package:business_banking/features/credit_card/ui/credit_card/credit_card_widget.dart';
 import 'package:business_banking/features/deposit_check/ui/1st_hub_card/deposit_check_card_widget.dart';
@@ -33,6 +34,7 @@ class HubScreen extends Screen {
             CreditCardWidget(),
             BudgetWidget(),
             DepositCheckCardWidget(),
+            AdHubCardWidget(),
           ],
         ),
       ),

--- a/business_banking/lib/locator.dart
+++ b/business_banking/lib/locator.dart
@@ -26,9 +26,8 @@ class ExampleLocator implements Locator {
   UrlLauncher? urlLauncher = UrlLauncher();
 
   PatchSimpleRestApi api = PatchSimpleRestApi(
-      baseUrl:
-          // 'http://localhost:3001/'); // Points to Mockoon instance
-          'http://192.168.1.219:3001/'); // Points to Mockoon instance
+      baseUrl: 'http://localhost:3001/'); // Points to Mockoon instance
+  //'http://192.168.1.219:3001/'); // Points to Mockoon instance
 
   Repository repository = Repository();
 

--- a/business_banking/lib/routes.dart
+++ b/business_banking/lib/routes.dart
@@ -4,6 +4,7 @@ import 'package:business_banking/features/hub/ui/hub_screen.dart';
 import 'package:business_banking/features/login/ui/login_feature_widget.dart';
 import 'package:flutter/material.dart';
 
+import 'features/advertisement/ui/ad_details/ad_details_widget.dart';
 import 'features/credit_card/ui/payment_request/credit_card_payment_request_widget.dart';
 import 'features/credit_card/ui/payment_response/credit_card_payment_response_widget.dart';
 import 'features/deposit_check/ui/2nd_data_entry/deposit_check_widget.dart';
@@ -25,6 +26,7 @@ abstract class BusinessBankingRouter {
       '/creditCardPaymentResponse';
   static const String depositCheckRoute = '/depositCheck';
   static const String depositCheckConfirmRoute = '/depositCheckConfirm';
+  static const String adDetails = '/adDetails';
 
   static Widget generate(String name) {
     switch (name) {
@@ -51,6 +53,9 @@ abstract class BusinessBankingRouter {
 
       case depositCheckConfirmRoute:
         return DepositCheckConfirmWidget();
+
+      case adDetails:
+        return AdDetailsWidget();
 
       default:
         return const PageNotFound();

--- a/business_banking/mockoon/business_banking_env.json
+++ b/business_banking/mockoon/business_banking_env.json
@@ -1,236 +1,11 @@
 {
-    "source": "mockoon:1.13.0",
+    "source": "mockoon:1.14.1",
     "data": [
         {
             "type": "environment",
             "item": {
                 "uuid": "",
-                "lastMigration": 13,
-                "name": "Demo API",
-                "endpointPrefix": "",
-                "latency": 0,
-                "port": 30,
-                "routes": [
-                    {
-                        "uuid": "",
-                        "documentation": "Use multiple responses with rules",
-                        "method": "post",
-                        "endpoint": "content/:param1",
-                        "responses": [
-                            {
-                                "uuid": "",
-                                "body": "{\n  \"Rules example\": \"Default response. Served if route param 'param1' is not present.\"\n}",
-                                "latency": 0,
-                                "statusCode": 200,
-                                "label": "Default response",
-                                "headers": [
-                                    {
-                                        "key": "",
-                                        "value": ""
-                                    }
-                                ],
-                                "filePath": "",
-                                "sendFileAsBody": false,
-                                "rules": [],
-                                "rulesOperator": "OR",
-                                "disableTemplating": false
-                            },
-                            {
-                                "uuid": "",
-                                "body": "{\n  \"Rules example\": \"Content XYZ. Served if route param 'param1' equals 'xyz'. (See in 'Rules' tab)\"\n}",
-                                "latency": 0,
-                                "statusCode": 200,
-                                "label": "Content XYZ",
-                                "headers": [
-                                    {
-                                        "key": "",
-                                        "value": ""
-                                    }
-                                ],
-                                "filePath": "",
-                                "sendFileAsBody": false,
-                                "rules": [
-                                    {
-                                        "target": "params",
-                                        "modifier": "param1",
-                                        "value": "xyz",
-                                        "isRegex": false
-                                    }
-                                ],
-                                "rulesOperator": "OR",
-                                "disableTemplating": false
-                            },
-                            {
-                                "uuid": "",
-                                "body": "{\n  \"Rules example\": \"Content not found. Served if route param 'param1' is not equal to 'xyz'. (See in 'Rules' tab)\"\n}\n",
-                                "latency": 0,
-                                "statusCode": 404,
-                                "label": "Content not found",
-                                "headers": [
-                                    {
-                                        "key": "",
-                                        "value": ""
-                                    }
-                                ],
-                                "filePath": "",
-                                "sendFileAsBody": false,
-                                "rules": [
-                                    {
-                                        "target": "params",
-                                        "modifier": "param1",
-                                        "value": "^(?!.*xyz).*$",
-                                        "isRegex": true
-                                    }
-                                ],
-                                "rulesOperator": "OR",
-                                "disableTemplating": false
-                            }
-                        ],
-                        "enabled": true,
-                        "randomResponse": false
-                    },
-                    {
-                        "uuid": "",
-                        "documentation": "Generate random body (JSON, text, CSV, etc) with templating",
-                        "method": "get",
-                        "endpoint": "users",
-                        "responses": [
-                            {
-                                "uuid": "",
-                                "body": "{\n  \"Templating example\": \"For more information about templating, click the blue 'i' above this editor\",\n  \"users\": [\n    {{# repeat (queryParam 'total' '10') }}\n      {\n        \"userId\": \"{{ faker 'random.number' min=10000 max=100000 }}\",\n        \"firstname\": \"{{ faker 'name.firstName' }}\",\n        \"lastname\": \"{{ faker 'name.lastName' }}\",\n        \"friends\": [\n          {{# repeat (faker 'random.number' 5) }}\n            {\n              \"id\": \"{{ faker 'random.uuid' }}\"\n            }\n          {{/ repeat }}\n        ]\n      },\n    {{/ repeat }}\n  ],\n  \"total\": \"{{queryParam 'total' '10'}}\"\n}",
-                                "latency": 0,
-                                "statusCode": 200,
-                                "label": "Creates 10 random users, or the amount specified in the 'total' query param",
-                                "headers": [
-                                    {
-                                        "key": "",
-                                        "value": ""
-                                    }
-                                ],
-                                "filePath": "",
-                                "sendFileAsBody": false,
-                                "rules": [],
-                                "rulesOperator": "OR",
-                                "disableTemplating": false
-                            }
-                        ],
-                        "enabled": true,
-                        "randomResponse": false
-                    },
-                    {
-                        "uuid": "",
-                        "documentation": "Serve a file dynamically depending on the path param 'pageName'.",
-                        "method": "get",
-                        "endpoint": "file/:pageName",
-                        "responses": [
-                            {
-                                "uuid": "",
-                                "body": "",
-                                "latency": 0,
-                                "statusCode": 200,
-                                "label": "Templating is also supported in file path",
-                                "headers": [
-                                    {
-                                        "key": "Content-Type",
-                                        "value": "text/html"
-                                    }
-                                ],
-                                "filePath": "./page{{urlParam 'pageName'}}.html",
-                                "sendFileAsBody": false,
-                                "rules": [],
-                                "rulesOperator": "OR",
-                                "disableTemplating": false
-                            }
-                        ],
-                        "enabled": true,
-                        "randomResponse": false
-                    },
-                    {
-                        "uuid": "",
-                        "documentation": "Path supports various patterns",
-                        "method": "put",
-                        "endpoint": "path/with/pattern(s)?/*",
-                        "responses": [
-                            {
-                                "uuid": "",
-                                "body": "The current path will match the following routes: \nhttp://localhost:3000/path/with/pattern/\nhttp://localhost:3000/path/with/patterns/\nhttp://localhost:3000/path/with/patterns/anything-else\n\nLearn more about Mockoon's routing: https://mockoon.com/docs/latest/routing",
-                                "latency": 0,
-                                "statusCode": 200,
-                                "label": "",
-                                "headers": [
-                                    {
-                                        "key": "Content-Type",
-                                        "value": "text/plain"
-                                    }
-                                ],
-                                "filePath": "",
-                                "sendFileAsBody": false,
-                                "rules": [],
-                                "rulesOperator": "OR",
-                                "disableTemplating": false
-                            }
-                        ],
-                        "enabled": true,
-                        "randomResponse": false
-                    },
-                    {
-                        "uuid": "",
-                        "documentation": "Can Mockoon forward or record entering requests?",
-                        "method": "get",
-                        "endpoint": "forward-and-record",
-                        "responses": [
-                            {
-                                "uuid": "",
-                                "body": "Mockoon can also act as a proxy and forward all entering requests that are not caught by declared routes. \nYou can activate this option in the environment settings ('cog' icon in the upper right corner). \nTo learn more: https://mockoon.com/docs/latest/proxy-mode\n\nAs always, all entering requests, and responses from the proxied server will be recorded ('clock' icon in the upper right corner).\nTo learn more: https://mockoon.com/docs/latest/requests-logging",
-                                "latency": 0,
-                                "statusCode": 200,
-                                "label": "",
-                                "headers": [
-                                    {
-                                        "key": "Content-Type",
-                                        "value": "text/plain"
-                                    }
-                                ],
-                                "filePath": "",
-                                "sendFileAsBody": false,
-                                "rules": [],
-                                "rulesOperator": "OR",
-                                "disableTemplating": false
-                            }
-                        ],
-                        "enabled": true,
-                        "randomResponse": false
-                    }
-                ],
-                "proxyMode": false,
-                "proxyHost": "",
-                "https": false,
-                "cors": true,
-                "headers": [
-                    {
-                        "key": "Content-Type",
-                        "value": "application/json"
-                    }
-                ],
-                "proxyReqHeaders": [
-                    {
-                        "key": "",
-                        "value": ""
-                    }
-                ],
-                "proxyResHeaders": [
-                    {
-                        "key": "",
-                        "value": ""
-                    }
-                ]
-            }
-        },
-        {
-            "type": "environment",
-            "item": {
-                "uuid": "",
-                "lastMigration": 13,
+                "lastMigration": 15,
                 "name": "Business Banking Env",
                 "endpointPrefix": "",
                 "latency": 0,
@@ -262,7 +37,8 @@
                             }
                         ],
                         "enabled": true,
-                        "randomResponse": false
+                        "randomResponse": false,
+                        "sequentialResponse": false
                     },
                     {
                         "uuid": "",
@@ -290,7 +66,8 @@
                             }
                         ],
                         "enabled": true,
-                        "randomResponse": false
+                        "randomResponse": false,
+                        "sequentialResponse": false
                     },
                     {
                         "uuid": "",
@@ -343,7 +120,8 @@
                             }
                         ],
                         "enabled": true,
-                        "randomResponse": false
+                        "randomResponse": false,
+                        "sequentialResponse": false
                     },
                     {
                         "uuid": "",
@@ -371,7 +149,8 @@
                             }
                         ],
                         "enabled": true,
-                        "randomResponse": false
+                        "randomResponse": false,
+                        "sequentialResponse": false
                     },
                     {
                         "uuid": "",
@@ -399,7 +178,8 @@
                             }
                         ],
                         "enabled": true,
-                        "randomResponse": false
+                        "randomResponse": false,
+                        "sequentialResponse": false
                     },
                     {
                         "uuid": "",
@@ -427,7 +207,8 @@
                             }
                         ],
                         "enabled": true,
-                        "randomResponse": false
+                        "randomResponse": false,
+                        "sequentialResponse": false
                     },
                     {
                         "uuid": "",
@@ -473,7 +254,8 @@
                             }
                         ],
                         "enabled": true,
-                        "randomResponse": false
+                        "randomResponse": false,
+                        "sequentialResponse": false
                     },
                     {
                         "uuid": "",
@@ -501,7 +283,8 @@
                             }
                         ],
                         "enabled": true,
-                        "randomResponse": false
+                        "randomResponse": false,
+                        "sequentialResponse": false
                     },
                     {
                         "uuid": "",
@@ -529,7 +312,8 @@
                             }
                         ],
                         "enabled": true,
-                        "randomResponse": false
+                        "randomResponse": false,
+                        "sequentialResponse": false
                     },
                     {
                         "uuid": "",
@@ -552,7 +336,8 @@
                             }
                         ],
                         "enabled": true,
-                        "randomResponse": false
+                        "randomResponse": false,
+                        "sequentialResponse": false
                     },
                     {
                         "uuid": "",
@@ -575,7 +360,8 @@
                             }
                         ],
                         "enabled": true,
-                        "randomResponse": false
+                        "randomResponse": false,
+                        "sequentialResponse": false
                     },
                     {
                         "uuid": "",
@@ -598,7 +384,8 @@
                             }
                         ],
                         "enabled": true,
-                        "randomResponse": false
+                        "randomResponse": false,
+                        "sequentialResponse": false
                     },
                     {
                         "uuid": "",
@@ -621,7 +408,8 @@
                             }
                         ],
                         "enabled": true,
-                        "randomResponse": false
+                        "randomResponse": false,
+                        "sequentialResponse": false
                     },
                     {
                         "uuid": "",
@@ -644,7 +432,8 @@
                             }
                         ],
                         "enabled": true,
-                        "randomResponse": false
+                        "randomResponse": false,
+                        "sequentialResponse": false
                     },
                     {
                         "uuid": "",
@@ -672,7 +461,32 @@
                             }
                         ],
                         "enabled": true,
-                        "randomResponse": false
+                        "randomResponse": false,
+                        "sequentialResponse": false
+                    },
+                    {
+                        "uuid": "",
+                        "documentation": "",
+                        "method": "get",
+                        "endpoint": "ads",
+                        "responses": [
+                            {
+                                "uuid": "",
+                                "body": "{\n  \"id\" : \"001\",\n  \"adTitle\": \"Get Asterisk Free Checking\",\n  \"adDescription\": \"No monthly maintenance fee with an Asterisk-Free checking account. No minimum deposit needed to open an Asterisk-Free accounton a Premier Savings Account when you own a checking account.\",\n  \"adImage\": \"https://www.huntington.com/-/media/hcom/Redesign/trends/trends-family-laughing.jpg?rev=17ac85a758274ee1bb98d719f16965e8&h=618&w=1100&la=en&hash=039637C335E33A24BFE99CFA42F1E24C\",\n  \"adIconImage\": \"https://www.huntington.com/-/media/Images/checking/Asterisk_free_checking_95x144.png?rev=483f2ab8aa2b46f0987d253d834e900b\"\n}",
+                                "latency": 0,
+                                "statusCode": 200,
+                                "label": "",
+                                "headers": [],
+                                "filePath": "",
+                                "sendFileAsBody": false,
+                                "rules": [],
+                                "rulesOperator": "OR",
+                                "disableTemplating": false
+                            }
+                        ],
+                        "enabled": true,
+                        "randomResponse": false,
+                        "sequentialResponse": false
                     }
                 ],
                 "proxyMode": false,
@@ -696,7 +510,8 @@
                         "key": "",
                         "value": ""
                     }
-                ]
+                ],
+                "proxyRemovePrefix": false
             }
         }
     ]

--- a/business_banking/pubspec.yaml
+++ b/business_banking/pubspec.yaml
@@ -19,15 +19,16 @@ dependencies:
 
   ### https://pub.dev/packages/pdf/versions/2.1.0
   pdf: ^2.1.0
+  network_image_mock: ^2.0.0
 
   ### https://pub.dev/packages/printing/versions/4.1.0
-  printing: ^4.1.0
+  #printing: ^5.2.1
 
 dev_dependencies:
   test: 
   flutter_test:
     sdk: flutter
-  mockito: 4.1.4 # Apache 2.0
+  mockito: 5.0.8 # Apache 2.0
   flutter_driver:
     sdk: flutter
 

--- a/business_banking/test/features/advertisement/api/ad_service_request_model_test.dart
+++ b/business_banking/test/features/advertisement/api/ad_service_request_model_test.dart
@@ -1,0 +1,20 @@
+import 'package:business_banking/features/advertisement/api/ad_service_request_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('AdServiceRequestModel initialization', () async {
+    final viewModel = AdServiceRequestModel(
+      id: 'id01',
+    );
+
+    expect(viewModel.id, 'id01');
+  });
+
+  test('AdServiceRequestModel toJson constructor', () async {
+    final viewModel = AdServiceRequestModel(
+      id: 'id01',
+    );
+
+    expect(viewModel.toJson(), {"id": 'id01'});
+  });
+}

--- a/business_banking/test/features/advertisement/api/ad_service_response_model_test.dart
+++ b/business_banking/test/features/advertisement/api/ad_service_response_model_test.dart
@@ -1,0 +1,47 @@
+import 'package:business_banking/features/advertisement/api/ad_service_response_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('AdServiceResponseModel fromJson initialization', () async {
+    final viewModel = AdServiceResponseModel.fromJson({
+      'id': 'id01',
+      'adTitle': 'Amazing Deal',
+      'adDescription': 'details about the deal',
+      'adImage': 'https://image.url',
+      'adIconImage': 'https://icon-image.url'
+    });
+    expect(viewModel.id, 'id01');
+    expect(viewModel.adTitle, 'Amazing Deal');
+    expect(viewModel.adDescription, 'details about the deal');
+    expect(viewModel.adIconImage, 'https://icon-image.url');
+    expect(viewModel.adImage, 'https://image.url');
+    expect(viewModel.props, [
+      viewModel.id,
+      viewModel.adTitle,
+      viewModel.adDescription,
+      viewModel.adImage,
+      viewModel.adIconImage,
+    ]);
+  });
+  test('AdServiceResponseModel default constructor initialization', () async {
+    final viewModel = AdServiceResponseModel(
+        'id01',
+        'Amazing Deal',
+        'details about the deal',
+        'https://icon-image.url',
+        'https://image.url');
+
+    expect(viewModel.id, 'id01');
+    expect(viewModel.adTitle, 'Amazing Deal');
+    expect(viewModel.adDescription, 'details about the deal');
+    expect(viewModel.adIconImage, 'https://icon-image.url');
+    expect(viewModel.adImage, 'https://image.url');
+    expect(viewModel.props, [
+      viewModel.id,
+      viewModel.adTitle,
+      viewModel.adDescription,
+      viewModel.adImage,
+      viewModel.adIconImage,
+    ]);
+  });
+}

--- a/business_banking/test/features/advertisement/api/ad_service_test.dart
+++ b/business_banking/test/features/advertisement/api/ad_service_test.dart
@@ -1,0 +1,26 @@
+import 'package:business_banking/features/advertisement/api/ad_service.dart';
+import 'package:business_banking/features/advertisement/api/ad_service_response_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('AdService created', () async {
+    AdService service = AdService();
+    expect(service.path, 'ads');
+  });
+
+  test('AdService parses response', () async {
+    final jsonResponse = {
+      'adTitle': 'Amazing Deal',
+      'adDescription': 'details about the deal'
+    };
+    final service = AdService();
+    AdServiceResponseModel responseModel = service.parseResponse(jsonResponse);
+    expect(responseModel, AdServiceResponseModel.fromJson(jsonResponse));
+  });
+
+  test('AdService GET request', () async {
+    AdService service = AdService();
+    final response = await service.request();
+    expect(response.isRight, isTrue);
+  });
+}

--- a/business_banking/test/features/advertisement/bloc/ad_bloc_test.dart
+++ b/business_banking/test/features/advertisement/bloc/ad_bloc_test.dart
@@ -1,0 +1,16 @@
+import 'package:business_banking/features/advertisement/bloc/ad_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('AdBloc initialization', () {
+    final bloc = AdBloc();
+    final pipe = bloc.adHubCardViewModelPipe;
+    expect(bloc.adHubCardViewModelPipe, pipe);
+  });
+
+  test('AdBloc dispose', () async {
+    final bloc = AdBloc();
+    bloc.dispose();
+    expect(bloc.adHubCardViewModelPipe.receive, emitsDone);
+  });
+}

--- a/business_banking/test/features/advertisement/bloc/ad_hub_card_service_adapter_test.dart
+++ b/business_banking/test/features/advertisement/bloc/ad_hub_card_service_adapter_test.dart
@@ -1,0 +1,29 @@
+import 'package:business_banking/features/advertisement/api/ad_service_response_model.dart';
+import 'package:business_banking/features/advertisement/bloc/ad_hub_card_service_adapter.dart';
+import 'package:business_banking/features/advertisement/model/ad_entity.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AccountInfo Service Adapter Test', () {
+    final testEntity = AdEntity(
+        id: '001',
+        adImage: 'imageURL will be here',
+        adIconImage: 'iconImageURL will be here',
+        adDescription: 'adDescription: Save way more than you expected!',
+        adTitle: 'ad Title: Save More!');
+
+    final tJsonResponse = {
+      "id": "001",
+      "adTitle": "ad Title: Save More!",
+      "adDescription": "adDescription: Save way more than you expected!",
+      "adImage": "imageURL will be here",
+      "adIconImage": "iconImageURL will be here"
+    };
+
+    test('Correct service adapter serialization', () async {
+      final entity = AdHubCardServiceAdapter().createEntity(
+          testEntity, AdServiceResponseModel.fromJson(tJsonResponse));
+      expect(entity, testEntity);
+    });
+  });
+}

--- a/business_banking/test/features/advertisement/bloc/ad_hub_card_use_case_test.dart
+++ b/business_banking/test/features/advertisement/bloc/ad_hub_card_use_case_test.dart
@@ -1,0 +1,15 @@
+import 'package:business_banking/features/advertisement/bloc/ad_hub_card_use_case.dart';
+import 'package:business_banking/features/advertisement/model/ad_hub_card_view_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('AdHubCardUseCase create', () async {
+    var _viewModel;
+    final useCase = AdHubCardUseCase((viewModel) {
+      _viewModel = viewModel;
+      return true;
+    });
+    await useCase.create();
+    expect(_viewModel, isA<AdHubCardViewModel>());
+  });
+}

--- a/business_banking/test/features/advertisement/model/ad_entity_test.dart
+++ b/business_banking/test/features/advertisement/model/ad_entity_test.dart
@@ -1,0 +1,65 @@
+import 'package:business_banking/features/advertisement/model/ad_entity.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('AdEntity initialization', () async {
+    final adEntity = AdEntity();
+    expect(adEntity.id, '');
+    expect(adEntity.adTitle, '');
+    expect(adEntity.adDescription, '');
+    expect(adEntity.adImage, '');
+    expect(adEntity.adIconImage, '');
+    expect(adEntity.props, [
+      adEntity.errors,
+      adEntity.id,
+      adEntity.adTitle,
+      adEntity.adDescription,
+      adEntity.adImage,
+      adEntity.adIconImage,
+    ]);
+  });
+
+  test('AdEntity merge successful', () async {
+    final adEntity = AdEntity(
+        id: 'id01',
+        adTitle: 'title01',
+        adDescription: 'description01',
+        adImage: 'image-url01',
+        adIconImage: 'icon-image-url01');
+
+    final adEntity02 = adEntity.merge(
+        id: 'id02',
+        adTitle: 'title02',
+        adDescription: 'description02',
+        adImage: 'image-url02',
+        adIconImage: 'icon-image-url02') as AdEntity;
+
+    expect(adEntity02.id, 'id02');
+    expect(adEntity02.adTitle, 'title02');
+    expect(adEntity02.adDescription, 'description02');
+    expect(adEntity02.adImage, 'image-url02');
+    expect(adEntity02.adIconImage, 'icon-image-url02');
+  });
+
+  test('AdEntity merge with entity with null fields', () async {
+    final adEntity = AdEntity(
+        id: 'id01',
+        adTitle: 'title01',
+        adDescription: 'description01',
+        adImage: 'image-url01',
+        adIconImage: 'icon-image-url01');
+
+    final adEntity02 = adEntity.merge(
+        id: null,
+        adTitle: null,
+        adDescription: null,
+        adImage: null,
+        adIconImage: null) as AdEntity;
+
+    expect(adEntity02.id, 'id01');
+    expect(adEntity02.adTitle, 'title01');
+    expect(adEntity02.adDescription, 'description01');
+    expect(adEntity02.adImage, 'image-url01');
+    expect(adEntity02.adIconImage, 'icon-image-url01');
+  });
+}

--- a/business_banking/test/features/advertisement/model/ad_hub_card_view_model_test.dart
+++ b/business_banking/test/features/advertisement/model/ad_hub_card_view_model_test.dart
@@ -1,0 +1,17 @@
+import 'package:business_banking/features/advertisement/model/ad_hub_card_view_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('AdHubCardViewModel initialization', () async {
+    final viewModel = AdHubCardViewModel(
+        adTitle: 'title',
+        adIconImage: 'https://url',
+        id: 'someid',
+        adImage: 'imageurl',
+        adDescription: 'adDesc');
+    expect(viewModel.adTitle, 'title');
+    expect(viewModel.adIconImage, 'https://url');
+    expect(viewModel.adDescription, 'adDesc');
+    expect(viewModel.props, [viewModel.adTitle, viewModel.adIconImage]);
+  });
+}

--- a/business_banking/test/features/advertisement/ui/ad_details/ad_details_presenter_test.dart
+++ b/business_banking/test/features/advertisement/ui/ad_details/ad_details_presenter_test.dart
@@ -1,0 +1,19 @@
+// @dart=2.9
+
+import 'package:business_banking/features/advertisement/bloc/ad_bloc.dart';
+import 'package:business_banking/features/advertisement/ui/ad_details/ad_details_presenter.dart';
+import 'package:clean_framework/clean_framework.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('AdDetailsPresenter Widget test', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: BlocProvider<AdBloc>(
+        create: (_) => AdBloc(),
+        child: AdDetailsPresenter(),
+      ),
+    ));
+    expect(find.byType(AdDetailsPresenter), findsOneWidget);
+  });
+}

--- a/business_banking/test/features/advertisement/ui/ad_details/ad_details_screen_test.dart
+++ b/business_banking/test/features/advertisement/ui/ad_details/ad_details_screen_test.dart
@@ -1,0 +1,26 @@
+// @dart=2.9
+import 'package:business_banking/features/advertisement/model/ad_hub_card_view_model.dart';
+import 'package:business_banking/features/advertisement/ui/ad_details/ad_details_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:network_image_mock/network_image_mock.dart';
+
+void main() {
+  Widget testWidget;
+  AdHubCardViewModel viewModel;
+
+  viewModel = AdHubCardViewModel(
+      adTitle: 'Awesome Ad!',
+      adIconImage: 'image-url',
+      id: 'id',
+      adDescription: 'desc',
+      adImage: 'imageurl');
+  testWidget = MaterialApp(
+    home: AdDetailsScreen(viewModel: viewModel),
+  );
+
+  testWidgets('AdDetailsScreen initialization', (tester) async {
+    await mockNetworkImagesFor(() => tester.pumpWidget(testWidget));
+    expect(find.byType(AdDetailsScreen), findsOneWidget);
+  });
+}

--- a/business_banking/test/features/advertisement/ui/ad_details/ad_details_widget_test.dart
+++ b/business_banking/test/features/advertisement/ui/ad_details/ad_details_widget_test.dart
@@ -1,0 +1,17 @@
+// @dart=2.9
+import 'package:business_banking/features/advertisement/ui/ad_details/ad_details_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:network_image_mock/network_image_mock.dart';
+
+void main() {
+  testWidgets('AdHubCardWidget initialization', (tester) async {
+    Widget adHubCard = AdDetailsWidget();
+    await mockNetworkImagesFor(() => tester.pumpWidget(adHubCard));
+    Widget testWidget = MaterialApp(
+      home: adHubCard,
+    );
+    await mockNetworkImagesFor(() => tester.pumpWidget(testWidget));
+    expect(find.byType(AdDetailsWidget), findsOneWidget);
+  });
+}

--- a/business_banking/test/features/advertisement/ui/ad_hub_card_presenter_actions_test.dart
+++ b/business_banking/test/features/advertisement/ui/ad_hub_card_presenter_actions_test.dart
@@ -1,0 +1,17 @@
+// @dart=2.9
+
+import 'package:business_banking/features/advertisement/ui/ad_hub_card_presenter.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+class BuildContextMock extends Mock implements BuildContext {}
+
+void main() {
+  AdHubCardPresenterActions actions = AdHubCardPresenterActions();
+
+  test('AdHubCardActions test', () async {
+    expect(() => actions.navigateToCreditCardDetails(BuildContextMock()),
+        throwsA(const TypeMatcher<AssertionError>()));
+  });
+}

--- a/business_banking/test/features/advertisement/ui/ad_hub_card_presenter_test.dart
+++ b/business_banking/test/features/advertisement/ui/ad_hub_card_presenter_test.dart
@@ -1,0 +1,29 @@
+// @dart=2.9
+
+import 'package:business_banking/features/advertisement/bloc/ad_bloc.dart';
+import 'package:business_banking/features/advertisement/ui/ad_hub_card_presenter.dart';
+import 'package:clean_framework/clean_framework.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('AdHubCardPresenter widget test', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: BlocProvider<AdBloc>(
+        create: (_) => AdBloc(),
+        child: AdHubCardPresenter(),
+      ),
+    ));
+    expect(find.byType(AdHubCardPresenter), findsOneWidget);
+  });
+
+  testWidgets('AdHubCardPresenter widget test', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: BlocProvider<AdBloc>(
+        create: (_) => AdBloc(),
+        child: AdHubCardPresenter(),
+      ),
+    ));
+    expect(find.byType(AdHubCardPresenter), findsOneWidget);
+  });
+}

--- a/business_banking/test/features/advertisement/ui/ad_hub_card_screen_test.dart
+++ b/business_banking/test/features/advertisement/ui/ad_hub_card_screen_test.dart
@@ -1,0 +1,43 @@
+// @dart=2.9
+import 'package:business_banking/features/advertisement/model/ad_hub_card_view_model.dart';
+import 'package:business_banking/features/advertisement/ui/ad_hub_card_presenter.dart';
+import 'package:business_banking/features/advertisement/ui/ad_hub_card_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:network_image_mock/network_image_mock.dart';
+
+class AdHubCardActionsMock extends Mock implements AdHubCardPresenterActions {}
+
+void main() {
+  AdHubCardActionsMock actions;
+  Widget testWidget;
+  AdHubCardViewModel viewModel;
+
+  viewModel = AdHubCardViewModel(
+      adTitle: 'Awesome Ad!',
+      adIconImage: 'image-url',
+      id: 'id',
+      adDescription: 'desc',
+      adImage: 'imageurl');
+  actions = AdHubCardActionsMock();
+  testWidget = MaterialApp(
+    home: AdHubCardScreen(viewModel: viewModel, actions: actions),
+  );
+
+  testWidgets('AdHubCardScreen initialization', (tester) async {
+    await mockNetworkImagesFor(() => tester.pumpWidget(testWidget));
+    expect(find.byType(AdHubCardScreen), findsOneWidget);
+  });
+
+  testWidgets('AdHubCardScreen onTap test', (tester) async {
+    await mockNetworkImagesFor(() => tester.pumpWidget(testWidget));
+    await tester.pumpWidget(testWidget);
+
+    // navigate to ad details screen
+    var widget = find.byKey(Key('Ad-Card-Learn-More-Button'));
+    expect(widget, findsOneWidget);
+    await tester.tap(widget);
+    verify(actions.navigateToCreditCardDetails(any)).called(1);
+  });
+}

--- a/business_banking/test/features/advertisement/ui/ad_hub_card_widget_test.dart
+++ b/business_banking/test/features/advertisement/ui/ad_hub_card_widget_test.dart
@@ -1,0 +1,17 @@
+// @dart=2.9
+import 'package:business_banking/features/advertisement/ui/ad_hub_card_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:network_image_mock/network_image_mock.dart';
+
+void main() {
+  testWidgets('AdHubCardWidget initialization', (tester) async {
+    Widget adHubCard = AdHubCardWidget();
+    await mockNetworkImagesFor(() => tester.pumpWidget(adHubCard));
+    Widget testWidget = MaterialApp(
+      home: adHubCard,
+    );
+    await mockNetworkImagesFor(() => tester.pumpWidget(testWidget));
+    expect(find.byType(AdHubCardWidget), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Dependencies: 

**in pubspec:** commented out **printing** dependency and updated **mockito** to 5.0.8. Otherwise `flutter pub get` complained.

Added network_image_mock - it's a package that creates mocks for easy testing of Flutter widgets that fetch images from network.
`network_image_mock: ^2.0.0`

Final Result ran on iOS Simulator with a Mockoon service:
Images are displayed with Image over network Flutter widget  
`Image.network('https://')`
![example](https://user-images.githubusercontent.com/30988129/119433483-3516c600-bccb-11eb-8654-8ecae1dd5f14.gif)

Tests added.

